### PR TITLE
Update action.php for preventing alignments of table cells from alte…

### DIFF
--- a/action.php
+++ b/action.php
@@ -849,7 +849,17 @@ class action_plugin_deeplautotranslate extends DokuWiki_Action_Plugin {
         $text = preg_replace('/\{\{([\s\S]*?)(\?[\s\S]*?)?((\|)([\s\S]*?))?}}/', '<ignore>{{${1}${2}${4}</ignore>${5}<ignore>}}</ignore>', $text);
 
         // prevent deepl from messing with tables
+        $text = str_replace("  ^  ", "<ignore>  ^  </ignore>", $text);
+        $text = str_replace("  ^ ", "<ignore>  ^ </ignore>", $text);
+        $text = str_replace(" ^  ", "<ignore> ^  </ignore>", $text);
+        $text = str_replace("^  ", "<ignore>^  </ignore>", $text);
+        $text = str_replace("  ^", "<ignore>  ^</ignore>", $text);
         $text = str_replace("^", "<ignore>^</ignore>", $text);
+        $text = str_replace("  |  ", "<ignore>  |  </ignore>", $text);
+        $text = str_replace("  | ", "<ignore>  | </ignore>", $text);
+        $text = str_replace(" |  ", "<ignore> |  </ignore>", $text);
+        $text = str_replace("|  ", "<ignore>|  </ignore>", $text);
+        $text = str_replace("  |", "<ignore>  |</ignore>", $text);
         $text = str_replace("|", "<ignore>|</ignore>", $text);
 
         // prevent deepl from doing strange things with dokuwiki syntax
@@ -893,7 +903,17 @@ class action_plugin_deeplautotranslate extends DokuWiki_Action_Plugin {
 
         // prevent deepl from messing with tables
         $text = str_replace("<ignore>^</ignore>", "^", $text);
+        $text = str_replace("<ignore>^  </ignore>", "^  ", $text);
+        $text = str_replace("<ignore>  ^</ignore>", "  ^", $text);
+        $text = str_replace("<ignore> ^  </ignore>", " ^  ", $text);
+        $text = str_replace("<ignore>  ^ </ignore>", "  ^ ", $text);
+        $text = str_replace("<ignore>  ^  </ignore>", "  ^  ", $text);
         $text = str_replace("<ignore>|</ignore>", "|", $text);
+        $text = str_replace("<ignore>|  </ignore>", "|  ", $text);
+        $text = str_replace("<ignore>  |</ignore>", "  |", $text);
+        $text = str_replace("<ignore> |  </ignore>", " |  ", $text);
+        $text = str_replace("<ignore>  | </ignore>", "  | ", $text);
+        $text = str_replace("<ignore>  |  </ignore>", "  |  ", $text);
 
         $text = str_replace("<ignore><ignore>''</ignore></ignore>", "''", $text);
         $text = str_replace("<ignore><ignore>//</ignore></ignore>", "//", $text);


### PR DESCRIPTION
This is a modification of the existing prevention of changes to table limiters "^" and "|". Beside the existing prevention of the single limiters 10 additional preventing-lines prevent alignments of table cells from altering, when "two" spaces are on the left or the right side of a limiter.