### PR TITLE
keep relative links when translating

### DIFF
--- a/action.php
+++ b/action.php
@@ -719,6 +719,24 @@ class action_plugin_deeplautotranslate extends DokuWiki_Action_Plugin {
         return explode(' ', $push_langs);
     }
 
+    /**
+     * Is the given ID a relative path?
+     *
+     * Always returns false if keep_relative is disabled.
+     *
+     * @param string $id
+     * @return bool
+     */
+    private function isRelativeLink($id)
+    {
+        if (!$this->getConf('keep_relative')) return false;
+        if ($id === '') return false;
+        if (strpos($id, ':') === false) return true;
+        if ($id[0] === '.') return true;
+        if ($id[0] === '~') return true;
+        return false;
+    }
+
     private function patch_links($text, $target_lang, $ns): string {
         /*
          * 1. Find links in [[ aa:bb ]] or [[ aa:bb | cc ]]
@@ -750,6 +768,7 @@ class action_plugin_deeplautotranslate extends DokuWiki_Action_Plugin {
             if (strpos($match[1], '\\\\') !== false) continue;
 
             $resolved_id = trim($match[1]);
+            if($this->isRelativeLink($resolved_id)) continue;
 
             resolve_pageid($ns, $resolved_id, $exists);
 
@@ -801,6 +820,8 @@ class action_plugin_deeplautotranslate extends DokuWiki_Action_Plugin {
 
             $resolved_id = trim($match[2]);
             $params = trim($match[3]);
+
+            if($this->isRelativeLink($resolved_id)) continue;
 
             resolve_mediaid($ns, $resolved_id, $exists);
 

--- a/conf/default.php
+++ b/conf/default.php
@@ -3,4 +3,4 @@
 $conf['mode'] = 'editor';
 $conf['api'] = 'free';
 $conf['show_button'] = true;
-
+$conf['keep_relative'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,10 +5,10 @@ $meta['api'] = array('multichoice', '_choices' => array('free', 'pro'));
 $meta['mode'] = array('multichoice', '_choices' => array('direct', 'editor'));
 $meta['show_button'] = array('onoff');
 $meta['push_langs'] = array('string');
-$meta['glossary_ns'] = array('string'); 
+$meta['glossary_ns'] = array('string');
 $meta['blacklist_regex'] = array('regex');
 $meta['direct_regex'] = array('regex');
 $meta['editor_regex'] = array('regex');
 $meta['ignored_expressions'] = array('string');
 $meta['default_lang_in_ns'] = array('onoff');
-
+$meta['keep_relative'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -11,4 +11,4 @@ $lang['direct_regex'] = 'Direct-Regex: All page names and namespaces matching th
 $lang['editor_regex'] = 'Editor-Regex: All page names and namespaces matching this regex will be translated in the editor mode';
 $lang['ignored_expressions'] = 'Expressions that won\'t be translated, seperated by \':\'';
 $lang['default_lang_in_ns'] = 'The default language is in a namespace (should normally not be the case)';
-
+$lang['keep_relative'] = 'Do not rewrite relative links when translating';


### PR DESCRIPTION
Relative links should usually work fine as-is and would not need any rewriting. Since there are no tests, I added a config to not change the default behaviour.