### PR TITLE
Add option to use old tag handling

### DIFF
--- a/action.php
+++ b/action.php
@@ -671,6 +671,11 @@ class action_plugin_deeplautotranslate extends DokuWiki_Action_Plugin {
             'text' => $text
         );
 
+        // use v1 of tag handling (not as strict XML parsing as default v2 - in 2026)
+        if ($this->getConf('tag_handling_v1')) {
+            $data['tag_handling_version'] = 'v1';
+        }
+
         // check if glossaries are enabled
         if ($this->get_glossary_ns()) {
             $src = substr($this->get_default_lang(), 0, 2);
@@ -705,6 +710,10 @@ class action_plugin_deeplautotranslate extends DokuWiki_Action_Plugin {
                 case 456:
                     throw new \Exception($this->getLang('msg_translation_fail_quota_exceeded'), 456);
                 default:
+                    if ($this->getConf('api_log_errors')) {
+                        $logger = \dokuwiki\Logger::getInstance('deeplautotranslate');
+                        $logger->log("$http->status " . $http->resp_body, $data['text']);
+                    }
                     throw new \Exception($this->getLang('msg_translation_fail'), $http->status ?: 500);
             }
         }

--- a/conf/default.php
+++ b/conf/default.php
@@ -2,5 +2,7 @@
 
 $conf['mode'] = 'editor';
 $conf['api'] = 'free';
+$conf['tag_handling_v1'] = 0;
+$conf['api_log_errors'] = 0;
 $conf['show_button'] = true;
 $conf['keep_relative'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -2,6 +2,8 @@
 
 $meta['api_key'] = array('string');
 $meta['api'] = array('multichoice', '_choices' => array('free', 'pro'));
+$meta['tag_handling_v1'] = array('onoff');
+$meta['api_log_errors'] = array('onoff');
 $meta['mode'] = array('multichoice', '_choices' => array('direct', 'editor'));
 $meta['show_button'] = array('onoff');
 $meta['push_langs'] = array('string');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2,6 +2,8 @@
 
 $lang['api_key'] = 'DeepL-API-Key';
 $lang['api'] = 'DeepL-API that should be used';
+$lang['tag_handling_v1'] = 'Use old, more lax, tag handling (v1) in the API. Try if translations fail.';
+$lang['api_log_errors'] = 'Log API errors';
 $lang['mode'] = 'Default operation mode of the plugin';
 $lang['show_button'] = 'Show button for forced-translations';
 $lang['push_langs'] = 'Space separated list of languages for push-translation (ISO codes)';


### PR DESCRIPTION
This PR adds a config option to use DeepL's old tag handling. A lot of syntax is posted unescaped to the API, and in v2 many requests are rejected. This addresses #19 

In addition, there is a new option to log API errors to plugin's own log facility. I hope it's okay that I didn't open a separate PR for this.