### PR TITLE
Fix: Undefined array key warnings in link and media translation

### DIFF
--- a/action.php
+++ b/action.php
@@ -796,10 +796,10 @@ class action_plugin_deeplautotranslate extends DokuWiki_Action_Plugin {
 
             if (!page_exists($lang_id)) {
                 // Page in target lang does not exist --> replace with absolute ID in case it was a relative ID
-                $new_link = '[[' . $resolved_id_full . $match[2] . $match[3] . ']]';
+                $new_link = '[[' . $resolved_id_full . ($match[2] ?? '') . ($match[3] ?? '') . ']]';
             } else {
                 // Page in target lang exists --> replace link
-                $new_link = '[[' . $lang_id . $match[2] . $match[3] . ']]';
+                $new_link = '[[' . $lang_id . ($match[2] ?? '') . ($match[3] ?? '') . ']]';
             }
 
             $text = str_replace($match[0], $new_link, $text);
@@ -830,7 +830,7 @@ class action_plugin_deeplautotranslate extends DokuWiki_Action_Plugin {
             if (substr($match[1], -1) == " ") $align_right = " ";
 
             $resolved_id = trim($match[2]);
-            $params = trim($match[3]);
+            $params = trim($match[3] ?? '');
 
             if($this->is_relative_link($resolved_id)) continue;
 
@@ -851,10 +851,10 @@ class action_plugin_deeplautotranslate extends DokuWiki_Action_Plugin {
 
             if (!file_exists($lang_id_fn)) {
                 // media in target lang does not exist --> replace with absolute ID in case it was a relative ID
-                $new_link = '{{' . $align_left . $resolved_id_full . $params . $align_right . $match[4] . '}}';
+                $new_link = '{{' . $align_left . $resolved_id_full . $params . $align_right . ($match[4] ?? '') . '}}';
             } else {
                 // media in target lang exists --> replace it
-                $new_link = '{{' . $align_left . $lang_id . $params . $align_right . $match[4] . '}}';
+                $new_link = '{{' . $align_left . $lang_id . $params . $align_right . ($match[4] ?? '') . '}}';
             }
 
             $text = str_replace($match[0], $new_link, $text);


### PR DESCRIPTION
Accessing optional regex capture groups without null checks caused PHP warnings when translating pages containing plain links ([[pageid]]) or media embeds ({{image.png}}) with no anchor, query params, or caption.


PHP Errors:
Warning: Undefined array key 3 in /wiki/lib/plugins/deeplautotranslate/action.php on line 833
Warning: Undefined array key 4 in /wiki/lib/plugins/deeplautotranslate/action.php on line 854 Automatic translation successful!
Warning: Cannot modify header information - headers already sent by (output started at /wiki/lib/plugins/deeplautotranslate/action.php:833) in /wiki/inc/common.php on line 1839